### PR TITLE
Implement importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ modules.
 
 To add a new dependency `github.com/author/dependency` to your Terraform provider:
 
-```
+```sh
 go get github.com/author/dependency
 go mod tidy
 ```
@@ -37,6 +37,32 @@ Ensure that you have an API user/sub-user on ClouDNS (requires a paid subscripti
 > Note that using a sub-user which you delegate a specific zone to is a **much** safer approach and should always be your first choice
 
 Once that is done, you must pre-create the zones you will want to manage on ClouDNS side (technically they are manageable through the API)
+
+### Import
+
+Records can be imported using:
+
+```sh
+terraform import ADDR "zone/id"
+```
+
+Example record and its import command:
+
+```hcl
+resource "cloudns_dns_record" "some-record" {
+  # ID: 123456789
+  # something.cloudns.net 600 in A 1.2.3.4
+  name  = ""
+  zone  = "something.cloudns.net"
+  type  = "A"
+  value = "1.2.3.4"
+  ttl   = "600"
+}
+```
+
+```sh
+terraform import cloudns_dns_record.some-record "something.cloudns.net/123456789"
+```
 
 ## Limitations
 

--- a/examples/resources/cloudns_dns_record/resource.tf
+++ b/examples/resources/cloudns_dns_record/resource.tf
@@ -1,7 +1,7 @@
 resource "cloudns_dns_record" "some-record" {
   # something.cloudns.net 600 in A 1.2.3.4
-  name  = "something"
-  zone  = "cloudns.net"
+  name  = ""
+  zone  = "something.cloudns.net"
   type  = "A"
   value = "1.2.3.4"
   ttl   = "600"

--- a/internal/cloudns/resource_dns_record_test.go
+++ b/internal/cloudns/resource_dns_record_test.go
@@ -12,97 +12,78 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDnsARecord(t *testing.T) {
-	testZone := os.Getenv(EnvVarAcceptanceTestsZone)
+var testZone = os.Getenv(EnvVarAcceptanceTestsZone)
 
+const recordTpl = `
+resource "cloudns_dns_record" "%s" {
+  name     = "%s"
+  zone     = "%s"
+  type     = "%s"
+  value    = "%s"
+  ttl      = "600"
+  priority = %s
+}
+`
+
+func record(recType string, resourceName string, name string, value string) string {
+	return fmt.Sprintf(recordTpl, resourceName, name, testZone, recType, value, "null")
+}
+
+func mxRecord(resourceName string, name string, value string, priority string) string {
+	return fmt.Sprintf(recordTpl, resourceName, name, testZone, "MX", value, priority)
+}
+
+func checkRecord(recType string, resourceName string, name string, value string) resource.TestCheckFunc {
+	path := fmt.Sprintf("cloudns_dns_record.%s", resourceName)
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(path, "name", name),
+		resource.TestCheckResourceAttr(path, "zone", testZone),
+		resource.TestCheckResourceAttr(path, "type", recType),
+		resource.TestCheckResourceAttr(path, "value", value),
+		resource.TestCheckResourceAttr(path, "ttl", "600"),
+	)
+}
+
+func checkMXRecord(resourceName string, name string, value string, priority string) resource.TestCheckFunc {
+	path := fmt.Sprintf("cloudns_dns_record.%s", resourceName)
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(path, "name", name),
+		resource.TestCheckResourceAttr(path, "zone", testZone),
+		resource.TestCheckResourceAttr(path, "type", "MX"),
+		resource.TestCheckResourceAttr(path, "value", value),
+		resource.TestCheckResourceAttr(path, "ttl", "600"),
+		resource.TestCheckResourceAttr(path, "priority", priority),
+	)
+}
+
+func TestAccDnsARecord(t *testing.T) {
+	testUuid := uuid.NewString()
 	initialRecordValue := "1.2.3.4"
 	updatedRecordValue := "5.6.7.8"
 
-	genUuid, err := uuid.NewRandom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	testUuid := genUuid.String()
-
-	initialRecord := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record" {
-  name  = "%s"
-  zone  = "%s"
-  type  = "A"
-  value = "%s"
-  ttl   = "600"
-}
-`, testUuid, testZone, initialRecordValue)
-
-	updatedRecord := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record" {
-  name  = "%s"
-  zone  = "%s"
-  type  = "A"
-  value = "%s"
-  ttl   = "600"
-}
-`, testUuid, testZone, updatedRecordValue)
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: initialRecord,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "name", testUuid),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "zone", testZone),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "type", "A"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "value", initialRecordValue),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "ttl", "600"),
-				),
+				Config: record("A", "some-record", testUuid, initialRecordValue),
+				Check:  checkRecord("A", "some-record", testUuid, initialRecordValue),
 			},
 			{
-				Config: updatedRecord,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "name", testUuid),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "zone", testZone),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "type", "A"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "value", updatedRecordValue),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "ttl", "600"),
-				),
+				Config: record("A", "some-record", testUuid, updatedRecordValue),
+				Check:  checkRecord("A", "some-record", testUuid, updatedRecordValue),
 			},
 		},
-		CheckDestroy: CheckDestroyedRecords(testZone),
+		CheckDestroy: CheckDestroyedRecords,
 	})
 }
 
 func TestAccDnsARecordMultiMatch(t *testing.T) {
-	testZone := os.Getenv(EnvVarAcceptanceTestsZone)
-
+	testUuid := uuid.NewString()
 	r1value := "1.2.3.4"
 	r2value := "5.6.7.8"
-
-	genUuid, err := uuid.NewRandom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	testUuid := genUuid.String()
-
-	r1res := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record-1" {
-  name  = "%s"
-  zone  = "%s"
-  type  = "A"
-  value = "%s"
-  ttl   = "600"
-}
-`, testUuid, testZone, r1value)
-
-	r2res := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record-2" {
-  name  = "%s"
-  zone  = "%s"
-  type  = "A"
-  value = "%s"
-  ttl   = "600"
-}
-`, testUuid, testZone, r2value)
+	r1res := record("A", "some-record-1", testUuid, r1value)
+	r2res := record("A", "some-record-2", testUuid, r2value)
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -111,175 +92,135 @@ resource "cloudns_dns_record" "some-record-2" {
 			{
 				Config: fmt.Sprintf("%s\n%s", r1res, r2res),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record-1", "value", r1value),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record-2", "value", r2value),
+					checkRecord("A", "some-record-1", testUuid, r1value),
+					checkRecord("A", "some-record-2", testUuid, r2value),
 				),
 			},
 		},
-		CheckDestroy: CheckDestroyedRecords(testZone),
+		CheckDestroy: CheckDestroyedRecords,
 	})
 }
 
 func TestAccDnsCNAMERecord(t *testing.T) {
-	testZone := os.Getenv(EnvVarAcceptanceTestsZone)
-
+	testUuid := uuid.NewString()
 	initialRecordValue := fmt.Sprintf("target-init.%s", testZone)
 	updatedRecordValue := fmt.Sprintf("target-updated.%s", testZone)
 
-	genUuid, err := uuid.NewRandom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	testUuid := genUuid.String()
-
-	initialRecord := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record" {
-  name  = "%s"
-  zone  = "%s"
-  type  = "CNAME"
-  value = "%s"
-  ttl   = "600"
-}
-`, testUuid, testZone, initialRecordValue)
-
-	updatedRecord := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record" {
-  name  = "%s"
-  zone  = "%s"
-  type  = "CNAME"
-  value = "%s"
-  ttl   = "600"
-}
-`, testUuid, testZone, updatedRecordValue)
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: initialRecord,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "name", testUuid),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "zone", testZone),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "type", "CNAME"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "value", initialRecordValue),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "ttl", "600"),
-				),
+				Config: record("CNAME", "some-record", testUuid, initialRecordValue),
+				Check:  checkRecord("CNAME", "some-record", testUuid, initialRecordValue),
 			},
 			{
-				Config: updatedRecord,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "name", testUuid),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "zone", testZone),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "type", "CNAME"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "value", updatedRecordValue),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "ttl", "600"),
-				),
+				Config: record("CNAME", "some-record", testUuid, updatedRecordValue),
+				Check:  checkRecord("CNAME", "some-record", testUuid, updatedRecordValue),
 			},
 		},
-		CheckDestroy: CheckDestroyedRecords(testZone),
+		CheckDestroy: CheckDestroyedRecords,
 	})
 }
 
 func TestAccDnsMXRecord(t *testing.T) {
-	testZone := os.Getenv(EnvVarAcceptanceTestsZone)
-
+	testUuid := uuid.NewString()
 	initialRecordValue := fmt.Sprintf("target-init.%s", testZone)
 	updatedRecordValue := fmt.Sprintf("target-updated.%s", testZone)
 
-	genUuid, err := uuid.NewRandom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	testUuid := genUuid.String()
-
-	initialRecord := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record" {
-  name     = "%s"
-  zone     = "%s"
-  type     = "MX"
-  value    = "%s"
-  ttl      = "600"
-  priority = "10"
-}
-`, testUuid, testZone, initialRecordValue)
-
-	updatedRecord := fmt.Sprintf(`
-resource "cloudns_dns_record" "some-record" {
-  name     = "%s"
-  zone     = "%s"
-  type     = "MX"
-  value    = "%s"
-  ttl      = "600"
-  priority = "0"
-}
-`, testUuid, testZone, updatedRecordValue)
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: initialRecord,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "name", testUuid),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "zone", testZone),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "type", "MX"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "value", initialRecordValue),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "ttl", "600"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "priority", "10"),
-				),
+				Config: mxRecord("some-record", testUuid, initialRecordValue, "10"),
+				Check:  checkMXRecord("some-record", testUuid, initialRecordValue, "10"),
 			},
 			{
-				Config: updatedRecord,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "name", testUuid),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "zone", testZone),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "type", "MX"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "value", updatedRecordValue),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "ttl", "600"),
-					resource.TestCheckResourceAttr("cloudns_dns_record.some-record", "priority", "0"),
-				),
+				Config: mxRecord("some-record", testUuid, updatedRecordValue, "0"),
+				Check:  checkMXRecord("some-record", testUuid, updatedRecordValue, "0"),
 			},
 		},
-		CheckDestroy: CheckDestroyedRecords(testZone),
+		CheckDestroy: CheckDestroyedRecords,
 	})
 }
 
-func CheckDestroyedRecords(zone string) func(state *terraform.State) error {
-	return func(state *terraform.State) error {
-		provider := testAccProvider
-		apiAccess := provider.Meta().(ClientConfig).apiAccess
-		records, err := cloudns.Zone{
-			Ztype:  "master",
-			Domain: zone,
-		}.List(&apiAccess)
+func TestAccDnsImportMXRecord(t *testing.T) {
+	testUuid := uuid.NewString()
 
-		if err != nil {
-			return err
-		}
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: mxRecord("record-to-import", testUuid, "mail.example.com", "10"),
+				Check:  checkMXRecord("record-to-import", testUuid, "mail.example.com", "10"),
+			},
+			{
+				ResourceName:        "cloudns_dns_record.record-to-import",
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", testZone),
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected single state, found: %+v", s)
+					}
+					rs := s[0]
+					expectedState := map[string]string{
+						"name":     testUuid,
+						"type":     "MX",
+						"value":    "mail.example.com",
+						"zone":     testZone,
+						"ttl":      "600",
+						"priority": "10",
+					}
+					for k, exp := range expectedState {
+						val := rs.Attributes[k]
+						if exp != val {
+							return fmt.Errorf("bad %#v: %#v expected: %#v", k, val, exp)
+						}
+					}
+					return nil
+				},
+			},
+		},
+		CheckDestroy: CheckDestroyedRecords,
+	})
+}
 
-		for _, rs := range state.RootModule().Resources {
-			if rs.Type != "cloudns_dns_record" {
-				continue
-			}
+func CheckDestroyedRecords(state *terraform.State) error {
+	provider := testAccProvider
+	apiAccess := provider.Meta().(ClientConfig).apiAccess
+	records, err := cloudns.Zone{
+		Ztype:  "master",
+		Domain: testZone,
+	}.List(&apiAccess)
 
-			fmt.Printf("Checking that cloudns_dns_record#%s was properly deleted\n", rs.Primary.ID)
-
-			for _, record := range records {
-				existingRecordId := record.ID
-				if rs.Primary.ID == existingRecordId {
-					return fmt.Errorf(
-						"record %s (%s.%s %d in %s %s) still exists",
-						record.ID,
-						record.Host,
-						record.Domain,
-						record.TTL,
-						record.Rtype,
-						record.Record,
-					)
-				}
-			}
-		}
-
-		return nil
+	if err != nil {
+		return err
 	}
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "cloudns_dns_record" {
+			continue
+		}
+
+		fmt.Printf("Checking that cloudns_dns_record#%s was properly deleted\n", rs.Primary.ID)
+
+		for _, record := range records {
+			existingRecordId := record.ID
+			if rs.Primary.ID == existingRecordId {
+				return fmt.Errorf(
+					"record %s (%s.%s %d in %s %s) still exists",
+					record.ID,
+					record.Host,
+					record.Domain,
+					record.TTL,
+					record.Rtype,
+					record.Record,
+				)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Based on https://github.com/mangadex-pub/terraform-provider-cloudns/pull/19. Differences:
- changed import ID format:  
   - from `$unused_part/$zone_$id` with `_` instead of `.` in `$zone` (example: `/something_cloudns.net_123456789`)
   - to `$zone/$id` (example: `something.cloudns.net/123456789`)
- set correct `id` in the state after importing https://github.com/mangadex-pub/terraform-provider-cloudns/pull/19#discussion_r1031613053
- didn't include this change -> https://github.com/mangadex-pub/terraform-provider-cloudns/pull/19#discussion_r856081899
- less verbose logging, some refactoring
- add import tests

Also, I have made some refactoring of `resource_dns_record_test.go`. 
If it is too much of refactoring, I can revert.